### PR TITLE
Show only 6 projects on main page ordered by date

### DIFF
--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -85,7 +85,7 @@ const projectsQuery = `
 `;
 
 const featuredProjectsQuery = `
-    "featuredProjects": *[_type == "project" && featured == true] | order(date.start desc) {
+    "featuredProjects": *[_type == "project" && featured == true] | order(date.start desc)[0...6] {
         ${baseProjectsFields}
     }
 `;


### PR DESCRIPTION
This PR limits the number of featured projects displayed on the main page to 6, showing the most recent projects first (ordered by date in descending order).

Changes:
- Modified the featuredProjectsQuery in src/sanity/lib/queries.ts to include "[0...6]" which limits the results to 6 projects
- Projects are already ordered by date with "order(date.start desc)" which ensures the most recent projects appear first

This change will make the main page more focused and highlight only the most recent work.